### PR TITLE
fix: Use ES module syntax in server

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,8 +1,13 @@
-const express = require('express');
-const { Pool } = require('pg');
-const bodyParser = require('body-parser');
-const cors = require('cors');
-const path = require('path');
+import express from 'express';
+import pg from 'pg';
+const { Pool } = pg;
+import bodyParser from 'body-parser';
+import cors from 'cors';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const app = express();
 const port = 3001;


### PR DESCRIPTION
This commit updates the `server/index.js` file to use ES module syntax (`import`/`export`) instead of CommonJS (`require`/`module.exports`).

This change is necessary because the `package.json` specifies `"type": "module"`, which makes all `.js` files ES modules by default.

The code has been updated to:
- Use `import` for all dependencies.
- Define `__dirname` using `import.meta.url`.